### PR TITLE
Keep music playing in overlays and restore config controls

### DIFF
--- a/UI & Audio/Musica y Audios/musica_de_fondo.gd
+++ b/UI & Audio/Musica y Audios/musica_de_fondo.gd
@@ -3,6 +3,7 @@ extends AudioStreamPlayer2D
 var started := false
 
 func _ready():
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	if not started:
 		play()
 		started = true

--- a/UI & Audio/config_overlay.gd
+++ b/UI & Audio/config_overlay.gd
@@ -4,11 +4,12 @@ signal overlay_closed
 signal menu_requested
 signal restart_requested
 
-@onready var panel: Panel = $CenterContainer/Panel
-@onready var volume_slider: HSlider = $"CenterContainer/Panel/VBoxContainer/VolumeContainer/VolumeSlider"
-@onready var slider_info: Label = $"CenterContainer/Panel/VBoxContainer/VolumeContainer/SliderInfo"
-@onready var mute_toggle: CheckButton = $"CenterContainer/Panel/VBoxContainer/MuteToggle"
-@onready var close_button: Button = $"CenterContainer/Panel/VBoxContainer/ButtonGrid/CloseButton"
+@onready var panel: Panel = get_node_or_null("CenterContainer/Panel") as Panel
+@onready var volume_slider: HSlider = get_node_or_null("CenterContainer/Panel/VBoxContainer/VolumeContainer/VolumeSlider") as HSlider
+@onready var slider_info: Label = get_node_or_null("CenterContainer/Panel/VBoxContainer/VolumeContainer/SliderInfo") as Label
+@onready var mute_toggle: CheckButton = get_node_or_null("CenterContainer/Panel/VBoxContainer/MuteToggle") as CheckButton
+@onready var close_button: Button = get_node_or_null("CenterContainer/Panel/VBoxContainer/ButtonGrid/CloseButton") as Button
+@onready var dimmer: ColorRect = get_node_or_null("Dimmer") as ColorRect
 
 var is_open: bool = false
 var pause_applied: bool = false
@@ -16,6 +17,7 @@ var ignore_toggle_update: bool = false
 var stored_volume: float = 1.0
 
 func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_WHEN_PAUSED
 	visible = false
 	if volume_slider:
 		stored_volume = max(volume_slider.value, 0.05)
@@ -23,6 +25,8 @@ func _ready() -> void:
 		volume_slider.value_changed.connect(_on_volume_value_changed)
 	if mute_toggle:
 		mute_toggle.button_pressed = volume_slider.value <= 0.001
+	if dimmer:
+		dimmer.gui_input.connect(_on_dimmer_gui_input)
 
 func open() -> void:
 	if is_open:
@@ -104,3 +108,11 @@ func _update_slider_info(value: float) -> void:
 		return
 	var percent: int = int(round(value * 100.0))
 	slider_info.text = "%d%%" % percent
+
+func _on_dimmer_gui_input(event: InputEvent) -> void:
+	if not is_open:
+		return
+	if event is InputEventMouseButton and event.pressed and event.button_index == MouseButton.LEFT:
+		_on_close_button_pressed()
+		if get_viewport():
+			get_viewport().set_input_as_handled()

--- a/UI & Audio/config_overlay.gd
+++ b/UI & Audio/config_overlay.gd
@@ -112,7 +112,7 @@ func _update_slider_info(value: float) -> void:
 func _on_dimmer_gui_input(event: InputEvent) -> void:
 	if not is_open:
 		return
-	if event is InputEventMouseButton and event.pressed and event.button_index == MouseButton.LEFT:
+	if event is InputEventMouseButton and event.pressed and event.button_index == MouseButton.MOUSE_BUTTON_LEFT:
 		_on_close_button_pressed()
 		if get_viewport():
 			get_viewport().set_input_as_handled()

--- a/UI & Audio/mode_intro_overlay.gd
+++ b/UI & Audio/mode_intro_overlay.gd
@@ -10,41 +10,41 @@ var is_showing: bool = false
 var pause_applied: bool = false
 
 func _ready() -> void:
-		hide()
-		if start_button:
-			start_button.pressed.connect(_on_start_button_pressed)
-		process_mode = Node.PROCESS_MODE_WHEN_PAUSED
+	process_mode = Node.PROCESS_MODE_WHEN_PAUSED
+	hide()
+	if start_button:
+		start_button.pressed.connect(_on_start_button_pressed)
 
 func show_intro(title: String, body: String) -> void:
-		if title_label:
-				title_label.text = title
-		if body_label:
-				body_label.text = body
-		show()
-		is_showing = true
-		if not get_tree().paused:
-				get_tree().paused = true
-				pause_applied = true
-		if start_button:
-				start_button.grab_focus()
+	if title_label:
+		title_label.text = title
+	if body_label:
+		body_label.text = body
+	show()
+	is_showing = true
+	if not get_tree().paused:
+		get_tree().paused = true
+		pause_applied = true
+	if start_button:
+		start_button.grab_focus()
 
 func close_intro() -> void:
-		if not is_showing:
-				return
-		hide()
-		is_showing = false
-		if pause_applied and get_tree().paused:
-				get_tree().paused = false
-		pause_applied = false
-		intro_closed.emit()
+	if not is_showing:
+		return
+	hide()
+	is_showing = false
+	if pause_applied and get_tree().paused:
+		get_tree().paused = false
+	pause_applied = false
+	intro_closed.emit()
 
 func _on_start_button_pressed() -> void:
-		close_intro()
+	close_intro()
 
 func _unhandled_input(event: InputEvent) -> void:
-		if not is_showing:
-				return
-		if event.is_action_pressed("ui_accept") or event.is_action_pressed("ui_cancel"):
-				close_intro()
-				if get_viewport():
-						get_viewport().set_input_as_handled()
+	if not is_showing:
+		return
+	if event.is_action_pressed("ui_accept") or event.is_action_pressed("ui_cancel"):
+		close_intro()
+		if get_viewport():
+			get_viewport().set_input_as_handled()


### PR DESCRIPTION
## Summary
- keep the background music playing while overlays pause the scene by processing the audio player even when paused
- allow the configuration overlay to function during pause, use safe node lookups, and close when clicking outside the panel
- align the intro overlay pause handling with when-paused processing for consistent behavior between modes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690107d041c083338637b19f77cf40fc