### PR TITLE
Add dice roll sounds and gameplay hint overlay

### DIFF
--- a/Assets/Dice/Dice.tscn
+++ b/Assets/Dice/Dice.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=9 format=3 uid="uid://bky2qlnu210xn"]
+[gd_scene load_steps=10 format=3 uid="uid://bky2qlnu210xn"]
 
 [ext_resource type="Script" uid="uid://c0gukvfg2yll8" path="res://Assets/Dice/dice.gd" id="1_0gri7"]
 [ext_resource type="ArrayMesh" uid="uid://n7f6x74pg8un" path="res://Assets/Dice/Dice.obj" id="1_y4aql"]
 [ext_resource type="PackedScene" uid="uid://c4pyewax2yche" path="res://Assets/Dice/dice_raycast.tscn" id="3_q0816"]
 [ext_resource type="AudioStream" uid="uid://cipg7yn02u6e4" path="res://UI & Audio/Musica y Audios/audiomass-output.mp3" id="4_ch4jn"]
 [ext_resource type="Script" uid="uid://nkdntcfagla6" path="res://Assets/Dice/audio_stream_player.gd" id="5_ch4jn"]
+[ext_resource type="AudioStream" path="res://Assets/sfx/dice throw.mp3" id="6_pwg56"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_q0816"]
 bounce = 0.3
@@ -60,5 +61,8 @@ opposite_side = 1
 stream = ExtResource("4_ch4jn")
 volume_db = 7.889
 script = ExtResource("5_ch4jn")
+
+[node name="ThrowSound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("6_pwg56")
 
 [connection signal="sleeping_state_changed" from="." to="." method="_on_sleeping_state_changed"]

--- a/Assets/Dice/dice.gd
+++ b/Assets/Dice/dice.gd
@@ -46,21 +46,21 @@ func _input(event):
 		_roll()
 
 func _roll():
-        # Reset state
-        is_rolling = true
-        set_sleeping(false)
-        freeze = false
-        can_emit = true
-        centering = true
-        linear_velocity = Vector3.ZERO
-        angular_velocity = Vector3.ZERO
+	# Reset state
+	is_rolling = true
+	set_sleeping(false)
+	freeze = false
+	can_emit = true
+	centering = true
+	linear_velocity = Vector3.ZERO
+	angular_velocity = Vector3.ZERO
 
-        if throw_sound:
-                throw_sound.stop()
-                throw_sound.play()
+	if throw_sound:
+		throw_sound.stop()
+		throw_sound.play()
 
-        # Random initial rotation
-        var axis = Vector3(randf(), randf(), randf()).normalized()
+	# Random initial rotation
+	var axis = Vector3(randf(), randf(), randf()).normalized()
 	var angle = randf_range(0, TAU)
 	self.set_transform(Transform3D(Basis(axis, angle), global_position))
 	set_sleeping(false)  # Force wake AFTER changing transform

--- a/Assets/Dice/dice.gd
+++ b/Assets/Dice/dice.gd
@@ -3,6 +3,7 @@ extends RigidBody3D
 @onready var raycasts = $Raycasts.get_children()
 @onready var pawn := $"../Player"
 @onready var collision_sound: AudioStreamPlayer = $"Dice sound"
+@onready var throw_sound: AudioStreamPlayer = $"ThrowSound"
 @onready var preguntas_panel = $"../PreguntasPanel" # reference to the question panel
 
 var start_pos
@@ -45,17 +46,21 @@ func _input(event):
 		_roll()
 
 func _roll():
-	# Reset state
-	is_rolling = true
-	set_sleeping(false)
-	freeze = false
-	can_emit = true
-	centering = true
-	linear_velocity = Vector3.ZERO
-	angular_velocity = Vector3.ZERO
+        # Reset state
+        is_rolling = true
+        set_sleeping(false)
+        freeze = false
+        can_emit = true
+        centering = true
+        linear_velocity = Vector3.ZERO
+        angular_velocity = Vector3.ZERO
 
-	# Random initial rotation
-	var axis = Vector3(randf(), randf(), randf()).normalized()
+        if throw_sound:
+                throw_sound.stop()
+                throw_sound.play()
+
+        # Random initial rotation
+        var axis = Vector3(randf(), randf(), randf()).normalized()
 	var angle = randf_range(0, TAU)
 	self.set_transform(Transform3D(Basis(axis, angle), global_position))
 	set_sleeping(false)  # Force wake AFTER changing transform

--- a/Assets/sfx/dice throw.mp3.import
+++ b/Assets/sfx/dice throw.mp3.import
@@ -1,0 +1,19 @@
+[remap]
+
+importer="mp3"
+type="AudioStreamMP3"
+uid="uid://6677fdc2a51d"
+path="res://.godot/imported/dice throw.mp3-e454997093b751950df1077b049c1bcc.mp3str"
+
+[deps]
+
+source_file="res://Assets/sfx/dice throw.mp3"
+dest_files=["res://.godot/imported/dice throw.mp3-e454997093b751950df1077b049c1bcc.mp3str"]
+
+[params]
+
+loop=false
+loop_offset=0
+bpm=0
+beat_count=0
+bar_beats=4

--- a/Assets/sfx/pawn land.mp3.import
+++ b/Assets/sfx/pawn land.mp3.import
@@ -1,0 +1,19 @@
+[remap]
+
+importer="mp3"
+type="AudioStreamMP3"
+uid="uid://b3guwb7x0708q"
+path="res://.godot/imported/pawn land.mp3-64a22f7612b29281a4d3f345b95209e6.mp3str"
+
+[deps]
+
+source_file="res://Assets/sfx/pawn land.mp3"
+dest_files=["res://.godot/imported/pawn land.mp3-64a22f7612b29281a4d3f345b95209e6.mp3str"]
+
+[params]
+
+loop=false
+loop_offset=0
+bpm=0
+beat_count=0
+bar_beats=4

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -5,6 +5,7 @@ signal pawn_finished_moving(spot: Marker3D)
 @onready var pawn: CharacterBody3D = self
 @onready var dice := $"../Dice"
 @export var game_spaces: Array[Marker3D]
+@onready var landing_sound: AudioStreamPlayer = $"PawnLandingSound"
 
 var pawn_landed: bool = true
 
@@ -74,7 +75,10 @@ func _process(delta: float) -> void:
 		pawn.global_position = pos
 
 func _on_pawn_finished_moving(_landed_spot: Node) -> void:
-	var vfx = preload("res://Assets/Vfx/PawnLandingVfx.tscn").instantiate()
-	get_tree().current_scene.add_child(vfx)
-	vfx.global_position = global_position   # pawn position
-	print("vfx")
+        var vfx = preload("res://Assets/Vfx/PawnLandingVfx.tscn").instantiate()
+        get_tree().current_scene.add_child(vfx)
+        vfx.global_position = global_position   # pawn position
+        print("vfx")
+        if landing_sound:
+                landing_sound.stop()
+                landing_sound.play()

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -75,10 +75,10 @@ func _process(delta: float) -> void:
 		pawn.global_position = pos
 
 func _on_pawn_finished_moving(_landed_spot: Node) -> void:
-        var vfx = preload("res://Assets/Vfx/PawnLandingVfx.tscn").instantiate()
-        get_tree().current_scene.add_child(vfx)
-        vfx.global_position = global_position   # pawn position
-        print("vfx")
-        if landing_sound:
-                landing_sound.stop()
-                landing_sound.play()
+		var vfx = preload("res://Assets/Vfx/PawnLandingVfx.tscn").instantiate()
+		get_tree().current_scene.add_child(vfx)
+		vfx.global_position = global_position   # pawn position
+		print("vfx")
+		if landing_sound:
+				landing_sound.stop()
+				landing_sound.play()

--- a/Player/player.tscn
+++ b/Player/player.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://cq0kl3xg7kong"]
+[gd_scene load_steps=5 format=3 uid="uid://cq0kl3xg7kong"]
 
 [ext_resource type="Script" uid="uid://c1vctitsj6loy" path="res://Player/player.gd" id="1_4ntmi"]
 [ext_resource type="PackedScene" uid="uid://c8g3ywh6lvn6m" path="res://Player/Pawn.glb" id="1_l8h54"]
+[ext_resource type="AudioStream" path="res://Assets/sfx/pawn land.mp3" id="2_5a0h6"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_l8h54"]
 size = Vector3(2.53223, 4.69348, 2.58984)
@@ -14,3 +15,6 @@ script = ExtResource("1_4ntmi")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.37506, 0)
 shape = SubResource("BoxShape3D_l8h54")
+
+[node name="PawnLandingSound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("2_5a0h6")

--- a/levels/main.gd
+++ b/levels/main.gd
@@ -36,6 +36,7 @@ const HEALTH_FLASH_ALPHA = 0.3
 @onready var config_button: BaseButton = $"ConfigButtonLayer/ConfigButtonRoot/ConfigButton"
 @onready var guide_overlay: CanvasLayer = $GuideOverlay
 @onready var guide_button: BaseButton = $"GuideButtonLayer/GuideButtonRoot/GuideButton"
+@onready var dice_hint_label: Label = $"DiceHintLayer/DiceHintRoot/DiceInstructionLabel"
 
 var default_light_color: Color = Color.WHITE
 var default_floor_color: Color = Color.WHITE
@@ -45,6 +46,9 @@ var overlay_tween: Tween
 var light_tween: Tween
 var extra_life_tween: Tween
 var defeat_forces_menu: bool = false
+var intro_sequence_completed: bool = false
+var tutorial_overlay_closed: bool = false
+var dice_hint_shown: bool = false
 
 func _ready() -> void:
 	RenderingServer.force_draw(true)
@@ -71,15 +75,16 @@ func _ready() -> void:
 		if preguntas_panel.has_signal("derrota_alcanzada"):
 			preguntas_panel.derrota_alcanzada.connect(_on_defeat_reached)
 
-	if restart_button:
-		restart_button.pressed.connect(_on_restart_button_pressed)
-	if menu_button:
-		menu_button.pressed.connect(_on_menu_button_pressed)
-	if guide_button:
-		guide_button.pressed.connect(_on_guide_button_pressed)
-	if guide_overlay:
-		guide_overlay.overlay_closed.connect(_on_guide_overlay_closed)
-	if exit_confirm_dialog:
+        if restart_button:
+                restart_button.pressed.connect(_on_restart_button_pressed)
+        if menu_button:
+                menu_button.pressed.connect(_on_menu_button_pressed)
+        if guide_button:
+                guide_button.pressed.connect(_on_guide_button_pressed)
+        if guide_overlay:
+                guide_overlay.overlay_closed.connect(_on_guide_overlay_closed)
+        tutorial_overlay_closed = guide_overlay == null or not guide_overlay.is_open
+        if exit_confirm_dialog:
 		exit_confirm_dialog.dialog_text = "¿Está seguro que quiere ir al menu principal?\nSu progreso no se guardará"
 		var ok_button: Button = exit_confirm_dialog.get_ok_button()
 		if ok_button:
@@ -94,18 +99,21 @@ func _ready() -> void:
 				config_overlay.overlay_closed.connect(_on_config_overlay_closed)
 				config_overlay.menu_requested.connect(_on_config_overlay_menu_requested)
 				config_overlay.restart_requested.connect(_on_config_overlay_restart_requested)
-		if intro_overlay:
-				intro_overlay.intro_closed.connect(_on_intro_overlay_closed)
-				intro_overlay.call_deferred("show_intro", "Modo fácil", "[center]Un recorrido relajado para practicar las categorías del juego sin presión.\nLanza el dado, aprende a tu ritmo y experimenta cada tema con calma.[/center]")
-		defeat_forces_menu = false
+                if intro_overlay:
+                                intro_overlay.intro_closed.connect(_on_intro_overlay_closed)
+                                intro_overlay.call_deferred("show_intro", "Modo fácil", "[center]Un recorrido relajado para practicar las categorías del juego sin presión.\nLanza el dado, aprende a tu ritmo y experimenta cada tema con calma.[/center]")
+        defeat_forces_menu = false
 
-		_apply_scene_color("default", 0.0)
-		_set_extra_life_label_visible(false)
+        _apply_scene_color("default", 0.0)
+        _set_extra_life_label_visible(false)
 
 func _input(event: InputEvent) -> void:
-	if event.is_action_pressed("ui_cancel"):
-		if guide_overlay and guide_overlay.is_open:
-			guide_overlay.close()
+        if dice_hint_label and dice_hint_label.visible:
+                if event is InputEventMouseButton and event.pressed and event.button_index == MouseButton.MOUSE_BUTTON_LEFT:
+                        _hide_dice_hint()
+        if event.is_action_pressed("ui_cancel"):
+                if guide_overlay and guide_overlay.is_open:
+                        guide_overlay.close()
 		elif config_overlay and config_overlay.is_open:
 			config_overlay.close()
 		else:
@@ -151,18 +159,42 @@ func _show_extra_life_toast(total_lives: int) -> void:
 	extra_life_tween.finished.connect(func(): _set_extra_life_label_visible(false))
 
 func _set_extra_life_label_visible(visible: bool) -> void:
-	if extra_life_label:
-		extra_life_label.visible = visible
-		if not visible:
-			extra_life_label.modulate.a = 0.0
+        if extra_life_label:
+                extra_life_label.visible = visible
+                if not visible:
+                        extra_life_label.modulate.a = 0.0
+
+func _try_show_dice_hint() -> void:
+        if dice_hint_shown:
+                return
+        if not intro_sequence_completed:
+                return
+        if not tutorial_overlay_closed:
+                return
+        _set_dice_hint_visible(true)
+
+func _set_dice_hint_visible(visible: bool) -> void:
+        if dice_hint_label == null:
+                return
+        dice_hint_label.visible = visible
+
+func _hide_dice_hint() -> void:
+        if dice_hint_label == null:
+                return
+        if not dice_hint_label.visible:
+                return
+        dice_hint_label.visible = false
+        dice_hint_shown = true
 
 func _on_guide_button_pressed() -> void:
-	if guide_overlay:
-		guide_overlay.open()
+        if guide_overlay:
+                guide_overlay.open()
 
 func _on_guide_overlay_closed() -> void:
-	if guide_button:
-		guide_button.grab_focus()
+        tutorial_overlay_closed = true
+        _try_show_dice_hint()
+        if guide_button:
+                guide_button.grab_focus()
 
 func _on_victory_reached(total_points: int) -> void:
 	_show_end_overlay(true, total_points)
@@ -265,8 +297,12 @@ func _on_config_overlay_restart_requested() -> void:
 		get_tree().reload_current_scene()
 
 func _on_intro_overlay_closed() -> void:
-		if config_button:
-				config_button.grab_focus()
+        intro_sequence_completed = true
+        if guide_overlay == null or not guide_overlay.is_open:
+                tutorial_overlay_closed = true
+        _try_show_dice_hint()
+        if config_button:
+                config_button.grab_focus()
 
 func _apply_scene_color(category: String, alpha: float) -> void:
 	var base_color = CATEGORY_COLORS.get(category, CATEGORY_COLORS["default"])

--- a/levels/main.gd
+++ b/levels/main.gd
@@ -75,17 +75,17 @@ func _ready() -> void:
 		if preguntas_panel.has_signal("derrota_alcanzada"):
 			preguntas_panel.derrota_alcanzada.connect(_on_defeat_reached)
 
-        if restart_button:
-                restart_button.pressed.connect(_on_restart_button_pressed)
-        if menu_button:
-                menu_button.pressed.connect(_on_menu_button_pressed)
-        if guide_button:
-                guide_button.pressed.connect(_on_guide_button_pressed)
-        if guide_overlay:
-                guide_overlay.overlay_closed.connect(_on_guide_overlay_closed)
-        tutorial_overlay_closed = guide_overlay == null or not guide_overlay.is_open
-        if exit_confirm_dialog:
-		exit_confirm_dialog.dialog_text = "¿Está seguro que quiere ir al menu principal?\nSu progreso no se guardará"
+		if restart_button:
+				restart_button.pressed.connect(_on_restart_button_pressed)
+		if menu_button:
+				menu_button.pressed.connect(_on_menu_button_pressed)
+		if guide_button:
+				guide_button.pressed.connect(_on_guide_button_pressed)
+		if guide_overlay:
+				guide_overlay.overlay_closed.connect(_on_guide_overlay_closed)
+		tutorial_overlay_closed = guide_overlay == null or not guide_overlay.is_open
+		if exit_confirm_dialog:
+			exit_confirm_dialog.dialog_text = "¿Está seguro que quiere ir al menu principal?\nSu progreso no se guardará"
 		var ok_button: Button = exit_confirm_dialog.get_ok_button()
 		if ok_button:
 			ok_button.text = "Sí"
@@ -99,23 +99,23 @@ func _ready() -> void:
 				config_overlay.overlay_closed.connect(_on_config_overlay_closed)
 				config_overlay.menu_requested.connect(_on_config_overlay_menu_requested)
 				config_overlay.restart_requested.connect(_on_config_overlay_restart_requested)
-                if intro_overlay:
-                                intro_overlay.intro_closed.connect(_on_intro_overlay_closed)
-                                intro_overlay.call_deferred("show_intro", "Modo fácil", "[center]Un recorrido relajado para practicar las categorías del juego sin presión.\nLanza el dado, aprende a tu ritmo y experimenta cada tema con calma.[/center]")
-        defeat_forces_menu = false
+				if intro_overlay:
+								intro_overlay.intro_closed.connect(_on_intro_overlay_closed)
+								intro_overlay.call_deferred("show_intro", "Modo fácil", "[center]Un recorrido relajado para practicar las categorías del juego sin presión.\nLanza el dado, aprende a tu ritmo y experimenta cada tema con calma.[/center]")
+		defeat_forces_menu = false
 
-        _apply_scene_color("default", 0.0)
-        _set_extra_life_label_visible(false)
+		_apply_scene_color("default", 0.0)
+		_set_extra_life_label_visible(false)
 
 func _input(event: InputEvent) -> void:
-        if dice_hint_label and dice_hint_label.visible:
-                if event is InputEventMouseButton and event.pressed and event.button_index == MouseButton.MOUSE_BUTTON_LEFT:
-                        _hide_dice_hint()
-        if event.is_action_pressed("ui_cancel"):
-                if guide_overlay and guide_overlay.is_open:
-                        guide_overlay.close()
-		elif config_overlay and config_overlay.is_open:
-			config_overlay.close()
+	if dice_hint_label and dice_hint_label.visible:
+		if event is InputEventMouseButton and event.pressed and event.button_index == MouseButton.MOUSE_BUTTON_LEFT:
+			_hide_dice_hint()
+		if event.is_action_pressed("ui_cancel"):
+			if guide_overlay and guide_overlay.is_open:
+				guide_overlay.close()
+			elif config_overlay and config_overlay.is_open:
+				config_overlay.close()
 		else:
 			_show_exit_dialog()
 	elif victory_overlay and victory_overlay.visible and event.is_action_pressed("ui_accept"):
@@ -159,42 +159,42 @@ func _show_extra_life_toast(total_lives: int) -> void:
 	extra_life_tween.finished.connect(func(): _set_extra_life_label_visible(false))
 
 func _set_extra_life_label_visible(visible: bool) -> void:
-        if extra_life_label:
-                extra_life_label.visible = visible
-                if not visible:
-                        extra_life_label.modulate.a = 0.0
+		if extra_life_label:
+				extra_life_label.visible = visible
+				if not visible:
+						extra_life_label.modulate.a = 0.0
 
 func _try_show_dice_hint() -> void:
-        if dice_hint_shown:
-                return
-        if not intro_sequence_completed:
-                return
-        if not tutorial_overlay_closed:
-                return
-        _set_dice_hint_visible(true)
+		if dice_hint_shown:
+				return
+		if not intro_sequence_completed:
+				return
+		if not tutorial_overlay_closed:
+				return
+		_set_dice_hint_visible(true)
 
 func _set_dice_hint_visible(visible: bool) -> void:
-        if dice_hint_label == null:
-                return
-        dice_hint_label.visible = visible
+		if dice_hint_label == null:
+				return
+		dice_hint_label.visible = visible
 
 func _hide_dice_hint() -> void:
-        if dice_hint_label == null:
-                return
-        if not dice_hint_label.visible:
-                return
-        dice_hint_label.visible = false
-        dice_hint_shown = true
+		if dice_hint_label == null:
+				return
+		if not dice_hint_label.visible:
+				return
+		dice_hint_label.visible = false
+		dice_hint_shown = true
 
 func _on_guide_button_pressed() -> void:
-        if guide_overlay:
-                guide_overlay.open()
+		if guide_overlay:
+				guide_overlay.open()
 
 func _on_guide_overlay_closed() -> void:
-        tutorial_overlay_closed = true
-        _try_show_dice_hint()
-        if guide_button:
-                guide_button.grab_focus()
+		tutorial_overlay_closed = true
+		_try_show_dice_hint()
+		if guide_button:
+				guide_button.grab_focus()
 
 func _on_victory_reached(total_points: int) -> void:
 	_show_end_overlay(true, total_points)
@@ -297,12 +297,12 @@ func _on_config_overlay_restart_requested() -> void:
 		get_tree().reload_current_scene()
 
 func _on_intro_overlay_closed() -> void:
-        intro_sequence_completed = true
-        if guide_overlay == null or not guide_overlay.is_open:
-                tutorial_overlay_closed = true
-        _try_show_dice_hint()
-        if config_button:
-                config_button.grab_focus()
+		intro_sequence_completed = true
+		if guide_overlay == null or not guide_overlay.is_open:
+				tutorial_overlay_closed = true
+		_try_show_dice_hint()
+		if config_button:
+				config_button.grab_focus()
 
 func _apply_scene_color(category: String, alpha: float) -> void:
 	var base_color = CATEGORY_COLORS.get(category, CATEGORY_COLORS["default"])

--- a/levels/main.tscn
+++ b/levels/main.tscn
@@ -318,6 +318,39 @@ text = "Menú principal"
 
 [node name="ModeIntroOverlay" parent="." instance=ExtResource("10_mk5p0")]
 
+[node name="DiceHintLayer" type="CanvasLayer" parent="."]
+layer = 30
+
+[node name="DiceHintRoot" type="Control" parent="DiceHintLayer"]
+anchors_preset = -1
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+offset_left = -520.0
+offset_top = 180.0
+offset_right = -40.0
+offset_bottom = 320.0
+grow_horizontal = 0
+grow_vertical = 0
+mouse_filter = 2
+
+[node name="DiceInstructionLabel" type="Label" parent="DiceHintLayer/DiceHintRoot"]
+visible = false
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme = ExtResource("7_6et1j")
+theme_override_colors/font_color = Color(0.87451, 0.952941, 0.941176, 1)
+theme_override_styles/normal = ExtResource("8_etqu2")
+text = "Dé click en cualquier lugar de la pantalla para tirar el dado"
+horizontal_alignment = 2
+vertical_alignment = 0
+autowrap_mode = 2
+
 [node name="GuideButtonLayer" type="CanvasLayer" parent="."]
 layer = 35
 


### PR DESCRIPTION
## Summary
- play a dedicated throw sound whenever the dice is rolled and trigger pawn landing audio on podium arrival
- add a right-aligned hint label that appears after the tutorial overlay and disappears on the first click
- wire the new UI hint into the mode flow so it only shows once after the intro/tutorial sequence

## Testing
- Not run (Godot tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6901815a49508333bdbbe285d300db5b