### PR TITLE
Add dice roll hint and gameplay audio cues

### DIFF
--- a/Assets/Dice/dice.gd
+++ b/Assets/Dice/dice.gd
@@ -45,22 +45,22 @@ func _input(event):
 		_roll()
 
 func _roll():
-        # Reset state
-        is_rolling = true
-        set_sleeping(false)
-        freeze = false
-        can_emit = true
-        centering = true
-        linear_velocity = Vector3.ZERO
-        angular_velocity = Vector3.ZERO
+		# Reset state
+		is_rolling = true
+		set_sleeping(false)
+		freeze = false
+		can_emit = true
+		centering = true
+		linear_velocity = Vector3.ZERO
+		angular_velocity = Vector3.ZERO
 
-        if Engine.has_singleton("SFX") and SFX.has_method("play_dice_throw"):
-                SFX.play_dice_throw()
+		if Engine.has_singleton("SFX") and SFX.has_method("play_dice_throw"):
+				SFX.play_dice_throw()
 
-        # Random initial rotation
-        var axis = Vector3(randf(), randf(), randf()).normalized()
-        var angle = randf_range(0, TAU)
-        self.set_transform(Transform3D(Basis(axis, angle), global_position))
+		# Random initial rotation
+		var axis = Vector3(randf(), randf(), randf()).normalized()
+		var angle = randf_range(0, TAU)
+		self.set_transform(Transform3D(Basis(axis, angle), global_position))
 	set_sleeping(false)  # Force wake AFTER changing transform
 
 	# Random throw

--- a/Assets/Dice/dice.gd
+++ b/Assets/Dice/dice.gd
@@ -45,19 +45,22 @@ func _input(event):
 		_roll()
 
 func _roll():
-	# Reset state
-	is_rolling = true
-	set_sleeping(false)
-	freeze = false
-	can_emit = true
-	centering = true
-	linear_velocity = Vector3.ZERO
-	angular_velocity = Vector3.ZERO
+        # Reset state
+        is_rolling = true
+        set_sleeping(false)
+        freeze = false
+        can_emit = true
+        centering = true
+        linear_velocity = Vector3.ZERO
+        angular_velocity = Vector3.ZERO
 
-	# Random initial rotation
-	var axis = Vector3(randf(), randf(), randf()).normalized()
-	var angle = randf_range(0, TAU)
-	self.set_transform(Transform3D(Basis(axis, angle), global_position))
+        if Engine.has_singleton("SFX") and SFX.has_method("play_dice_throw"):
+                SFX.play_dice_throw()
+
+        # Random initial rotation
+        var axis = Vector3(randf(), randf(), randf()).normalized()
+        var angle = randf_range(0, TAU)
+        self.set_transform(Transform3D(Basis(axis, angle), global_position))
 	set_sleeping(false)  # Force wake AFTER changing transform
 
 	# Random throw

--- a/Assets/sfx/dice throw.mp3.import
+++ b/Assets/sfx/dice throw.mp3.import
@@ -1,0 +1,19 @@
+[remap]
+
+importer="mp3"
+type="AudioStreamMP3"
+uid="uid://dp06lx38efhcs"
+path="res://.godot/imported/dice throw.mp3-e454997093b751950df1077b049c1bcc.mp3str"
+
+[deps]
+
+source_file="res://Assets/sfx/dice throw.mp3"
+dest_files=["res://.godot/imported/dice throw.mp3-e454997093b751950df1077b049c1bcc.mp3str"]
+
+[params]
+
+loop=false
+loop_offset=0
+bpm=0
+beat_count=0
+bar_beats=4

--- a/Assets/sfx/pawn land.mp3.import
+++ b/Assets/sfx/pawn land.mp3.import
@@ -1,0 +1,19 @@
+[remap]
+
+importer="mp3"
+type="AudioStreamMP3"
+uid="uid://dp7ujk1x3d8ix"
+path="res://.godot/imported/pawn land.mp3-64a22f7612b29281a4d3f345b95209e6.mp3str"
+
+[deps]
+
+source_file="res://Assets/sfx/pawn land.mp3"
+dest_files=["res://.godot/imported/pawn land.mp3-64a22f7612b29281a4d3f345b95209e6.mp3str"]
+
+[params]
+
+loop=false
+loop_offset=0
+bpm=0
+beat_count=0
+bar_beats=4

--- a/Assets/sfx/sfx_manager.gd
+++ b/Assets/sfx/sfx_manager.gd
@@ -4,6 +4,8 @@ const CORRECT_STREAM: AudioStream = preload("res://Assets/sfx/correct_answer.mp3
 const WRONG_STREAM: AudioStream = preload("res://Assets/sfx/wrong_answer.mp3")
 const FAILURE_STREAM: AudioStream = preload("res://Assets/sfx/failure.mp3")
 const SUCCESS_STREAM: AudioStream = preload("res://Assets/sfx/success.mp3")
+const DICE_THROW_STREAM: AudioStream = preload("res://Assets/sfx/dice throw.mp3")
+const PAWN_LAND_STREAM: AudioStream = preload("res://Assets/sfx/pawn land.mp3")
 const SELECT_STREAMS: Array[AudioStream] = [
 	preload("res://Assets/sfx/select_button1.mp3"),
 	preload("res://Assets/sfx/select_button2.mp3")
@@ -15,20 +17,24 @@ var wrong_player: AudioStreamPlayer
 var failure_player: AudioStreamPlayer
 var success_player: AudioStreamPlayer
 var select_player: AudioStreamPlayer
+var dice_throw_player: AudioStreamPlayer
+var pawn_land_player: AudioStreamPlayer
 
 func _ready() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
 	rng.randomize()
 	correct_player = _create_player("CorrectPlayer", CORRECT_STREAM, 4)
-	wrong_player = _create_player("WrongPlayer", WRONG_STREAM, 4)
-	failure_player = _create_player("FailurePlayer", FAILURE_STREAM, 2)
-	success_player = _create_player("SuccessPlayer", SUCCESS_STREAM, 2)
-	var initial_select_stream: AudioStream = SELECT_STREAMS[0] if not SELECT_STREAMS.is_empty() else null
-	select_player = _create_player("SelectPlayer", initial_select_stream, 12)
-	var tree := get_tree()
-	if tree:
-		tree.node_added.connect(_on_node_added)
-		_scan_tree(tree.root)
+        wrong_player = _create_player("WrongPlayer", WRONG_STREAM, 4)
+        failure_player = _create_player("FailurePlayer", FAILURE_STREAM, 2)
+        success_player = _create_player("SuccessPlayer", SUCCESS_STREAM, 2)
+        var initial_select_stream: AudioStream = SELECT_STREAMS[0] if not SELECT_STREAMS.is_empty() else null
+        select_player = _create_player("SelectPlayer", initial_select_stream, 12)
+        dice_throw_player = _create_player("DiceThrowPlayer", DICE_THROW_STREAM, 2)
+        pawn_land_player = _create_player("PawnLandPlayer", PAWN_LAND_STREAM, 4)
+        var tree := get_tree()
+        if tree:
+                tree.node_added.connect(_on_node_added)
+                _scan_tree(tree.root)
 
 func play_correct_answer() -> void:
 	_play_stream(correct_player, CORRECT_STREAM)
@@ -43,11 +49,17 @@ func play_success() -> void:
 	_play_stream(success_player, SUCCESS_STREAM)
 
 func play_select() -> void:
-	if SELECT_STREAMS.is_empty():
-		return
-	var index := rng.randi_range(0, SELECT_STREAMS.size() - 1)
-	var stream := SELECT_STREAMS[index]
-	_play_stream(select_player, stream)
+        if SELECT_STREAMS.is_empty():
+                return
+        var index := rng.randi_range(0, SELECT_STREAMS.size() - 1)
+        var stream := SELECT_STREAMS[index]
+        _play_stream(select_player, stream)
+
+func play_dice_throw() -> void:
+        _play_stream(dice_throw_player, DICE_THROW_STREAM)
+
+func play_pawn_land() -> void:
+        _play_stream(pawn_land_player, PAWN_LAND_STREAM)
 
 func _create_player(player_name: String, stream: AudioStream, polyphony: int) -> AudioStreamPlayer:
 	var player := AudioStreamPlayer.new()

--- a/Assets/sfx/sfx_manager.gd
+++ b/Assets/sfx/sfx_manager.gd
@@ -24,17 +24,17 @@ func _ready() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
 	rng.randomize()
 	correct_player = _create_player("CorrectPlayer", CORRECT_STREAM, 4)
-        wrong_player = _create_player("WrongPlayer", WRONG_STREAM, 4)
-        failure_player = _create_player("FailurePlayer", FAILURE_STREAM, 2)
-        success_player = _create_player("SuccessPlayer", SUCCESS_STREAM, 2)
-        var initial_select_stream: AudioStream = SELECT_STREAMS[0] if not SELECT_STREAMS.is_empty() else null
-        select_player = _create_player("SelectPlayer", initial_select_stream, 12)
-        dice_throw_player = _create_player("DiceThrowPlayer", DICE_THROW_STREAM, 2)
-        pawn_land_player = _create_player("PawnLandPlayer", PAWN_LAND_STREAM, 4)
-        var tree := get_tree()
-        if tree:
-                tree.node_added.connect(_on_node_added)
-                _scan_tree(tree.root)
+	wrong_player = _create_player("WrongPlayer", WRONG_STREAM, 4)
+	failure_player = _create_player("FailurePlayer", FAILURE_STREAM, 2)
+	success_player = _create_player("SuccessPlayer", SUCCESS_STREAM, 2)
+	var initial_select_stream: AudioStream = SELECT_STREAMS[0] if not SELECT_STREAMS.is_empty() else null
+	select_player = _create_player("SelectPlayer", initial_select_stream, 12)
+	dice_throw_player = _create_player("DiceThrowPlayer", DICE_THROW_STREAM, 2)
+	pawn_land_player = _create_player("PawnLandPlayer", PAWN_LAND_STREAM, 4)
+	var tree := get_tree()
+	if tree:
+		tree.node_added.connect(_on_node_added)
+		_scan_tree(tree.root)
 
 func play_correct_answer() -> void:
 	_play_stream(correct_player, CORRECT_STREAM)
@@ -49,17 +49,17 @@ func play_success() -> void:
 	_play_stream(success_player, SUCCESS_STREAM)
 
 func play_select() -> void:
-        if SELECT_STREAMS.is_empty():
-                return
-        var index := rng.randi_range(0, SELECT_STREAMS.size() - 1)
-        var stream := SELECT_STREAMS[index]
-        _play_stream(select_player, stream)
+	if SELECT_STREAMS.is_empty():
+		return
+	var index := rng.randi_range(0, SELECT_STREAMS.size() - 1)
+	var stream := SELECT_STREAMS[index]
+	_play_stream(select_player, stream)
 
 func play_dice_throw() -> void:
-        _play_stream(dice_throw_player, DICE_THROW_STREAM)
+	_play_stream(dice_throw_player, DICE_THROW_STREAM)
 
 func play_pawn_land() -> void:
-        _play_stream(pawn_land_player, PAWN_LAND_STREAM)
+	_play_stream(pawn_land_player, PAWN_LAND_STREAM)
 
 func _create_player(player_name: String, stream: AudioStream, polyphony: int) -> AudioStreamPlayer:
 	var player := AudioStreamPlayer.new()

--- a/levels/main.gd
+++ b/levels/main.gd
@@ -106,18 +106,18 @@ func _ready() -> void:
 		_set_extra_life_label_visible(false)
 
 func _input(event: InputEvent) -> void:
-        if event.is_action_pressed("ui_cancel"):
-                if guide_overlay and guide_overlay.is_open:
-                        guide_overlay.close()
-                elif config_overlay and config_overlay.is_open:
-                        config_overlay.close()
-                else:
-                        _show_exit_dialog()
-        elif event.is_action_pressed("LeftClick"):
-                if click_hint_active:
-                        _hide_click_hint()
-        elif victory_overlay and victory_overlay.visible and event.is_action_pressed("ui_accept"):
-                _restart_game()
+	if event.is_action_pressed("ui_cancel"):
+		if guide_overlay and guide_overlay.is_open:
+			guide_overlay.close()
+		elif config_overlay and config_overlay.is_open:
+			config_overlay.close()
+		else:
+			_show_exit_dialog()
+	elif event.is_action_pressed("LeftClick"):
+		if click_hint_active:
+			_hide_click_hint()
+		elif victory_overlay and victory_overlay.visible and event.is_action_pressed("ui_accept"):
+			_restart_game()
 
 func _on_category_reached(category: String) -> void:
 	current_category = category
@@ -167,10 +167,10 @@ func _on_guide_button_pressed() -> void:
 		guide_overlay.open()
 
 func _on_guide_overlay_closed() -> void:
-        if guide_button:
-                guide_button.grab_focus()
-        if not click_hint_shown:
-                _show_click_hint()
+	if guide_button:
+		guide_button.grab_focus()
+	if not click_hint_shown:
+		_show_click_hint()
 
 func _on_victory_reached(total_points: int) -> void:
 	_show_end_overlay(true, total_points)
@@ -224,19 +224,19 @@ func _show_end_overlay(victory: bool, total_points: int) -> void:
 func _lock_gameplay() -> void:
 	if dice and dice.has_method("lock_roll"):
 		dice.lock_roll()
-        if preguntas_panel:
-                preguntas_panel.hide()
+	if preguntas_panel:
+		preguntas_panel.hide()
 
 func _show_click_hint() -> void:
-        click_hint_shown = true
-        click_hint_active = true
-        if click_hint_label:
-                click_hint_label.visible = true
+	click_hint_shown = true
+	click_hint_active = true
+	if click_hint_label:
+		click_hint_label.visible = true
 
 func _hide_click_hint() -> void:
-        click_hint_active = false
-        if click_hint_label:
-                click_hint_label.visible = false
+	click_hint_active = false
+	if click_hint_label:
+		click_hint_label.visible = false
 
 func _on_restart_button_pressed() -> void:
 	_restart_game()

--- a/levels/main.gd
+++ b/levels/main.gd
@@ -22,6 +22,7 @@ const HEALTH_FLASH_ALPHA = 0.3
 @onready var spots: Node = $Spots
 @onready var preguntas_panel: Node = $PreguntasPanel
 @onready var extra_life_label: Label = $HUDMessages/ExtraLifeLabel
+@onready var click_hint_label: Label = $"HUDMessages/ClickHintLabel"
 @onready var score_label: Label = $Score
 @onready var health_label: Label = $Health
 @onready var dice: Node = $Dice
@@ -45,6 +46,8 @@ var overlay_tween: Tween
 var light_tween: Tween
 var extra_life_tween: Tween
 var defeat_forces_menu: bool = false
+var click_hint_shown: bool = false
+var click_hint_active: bool = false
 
 func _ready() -> void:
 	RenderingServer.force_draw(true)
@@ -103,15 +106,18 @@ func _ready() -> void:
 		_set_extra_life_label_visible(false)
 
 func _input(event: InputEvent) -> void:
-	if event.is_action_pressed("ui_cancel"):
-		if guide_overlay and guide_overlay.is_open:
-			guide_overlay.close()
-		elif config_overlay and config_overlay.is_open:
-			config_overlay.close()
-		else:
-			_show_exit_dialog()
-	elif victory_overlay and victory_overlay.visible and event.is_action_pressed("ui_accept"):
-		_restart_game()
+        if event.is_action_pressed("ui_cancel"):
+                if guide_overlay and guide_overlay.is_open:
+                        guide_overlay.close()
+                elif config_overlay and config_overlay.is_open:
+                        config_overlay.close()
+                else:
+                        _show_exit_dialog()
+        elif event.is_action_pressed("LeftClick"):
+                if click_hint_active:
+                        _hide_click_hint()
+        elif victory_overlay and victory_overlay.visible and event.is_action_pressed("ui_accept"):
+                _restart_game()
 
 func _on_category_reached(category: String) -> void:
 	current_category = category
@@ -161,8 +167,10 @@ func _on_guide_button_pressed() -> void:
 		guide_overlay.open()
 
 func _on_guide_overlay_closed() -> void:
-	if guide_button:
-		guide_button.grab_focus()
+        if guide_button:
+                guide_button.grab_focus()
+        if not click_hint_shown:
+                _show_click_hint()
 
 func _on_victory_reached(total_points: int) -> void:
 	_show_end_overlay(true, total_points)
@@ -216,8 +224,19 @@ func _show_end_overlay(victory: bool, total_points: int) -> void:
 func _lock_gameplay() -> void:
 	if dice and dice.has_method("lock_roll"):
 		dice.lock_roll()
-	if preguntas_panel:
-		preguntas_panel.hide()
+        if preguntas_panel:
+                preguntas_panel.hide()
+
+func _show_click_hint() -> void:
+        click_hint_shown = true
+        click_hint_active = true
+        if click_hint_label:
+                click_hint_label.visible = true
+
+func _hide_click_hint() -> void:
+        click_hint_active = false
+        if click_hint_label:
+                click_hint_label.visible = false
 
 func _on_restart_button_pressed() -> void:
 	_restart_game()

--- a/levels/main.tscn
+++ b/levels/main.tscn
@@ -249,6 +249,25 @@ text = "+1 Vida extra!"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="ClickHintLabel" type="Label" parent="HUDMessages"]
+visible = false
+anchors_preset = 10
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+offset_left = -520.0
+offset_top = 180.0
+offset_right = -40.0
+offset_bottom = 260.0
+theme = ExtResource("7_6et1j")
+theme_override_colors/font_color = Color(0.901961, 0.960784, 0.945098, 1)
+theme_override_font_sizes/font_size = 30
+text = "Dé click en cualquier lugar de la pantalla para tirar el dado"
+autowrap_mode = 1
+horizontal_alignment = 2
+vertical_alignment = 1
+
 [node name="VictoryOverlay" type="CanvasLayer" parent="."]
 layer = 20
 visible = false

--- a/levels/spots.gd
+++ b/levels/spots.gd
@@ -80,12 +80,14 @@ func _on_pawn_finished_moving(landed_spot: Node) -> void:
 					podium = child
 					break
 
-		if podium:
-				var category: String = podium.get_meta("category")
+                if podium:
+                                if Engine.has_singleton("SFX") and SFX.has_method("play_pawn_land"):
+                                                SFX.play_pawn_land()
+                                var category: String = podium.get_meta("category")
 
-				# 🔥 Caso especial: Podio de vida extra
-				if category == "Health":
-						var preguntas_panel = $"../PreguntasPanel"
+                                # 🔥 Caso especial: Podio de vida extra
+                                if category == "Health":
+                                                var preguntas_panel = $"../PreguntasPanel"
 						if preguntas_panel:
 								preguntas_panel.vidas += 1
 								preguntas_panel._update_health_label()

--- a/levels/spots.gd
+++ b/levels/spots.gd
@@ -80,14 +80,14 @@ func _on_pawn_finished_moving(landed_spot: Node) -> void:
 					podium = child
 					break
 
-                if podium:
-                                if Engine.has_singleton("SFX") and SFX.has_method("play_pawn_land"):
-                                                SFX.play_pawn_land()
-                                var category: String = podium.get_meta("category")
+				if podium:
+								if Engine.has_singleton("SFX") and SFX.has_method("play_pawn_land"):
+												SFX.play_pawn_land()
+								var category: String = podium.get_meta("category")
 
-                                # 🔥 Caso especial: Podio de vida extra
-                                if category == "Health":
-                                                var preguntas_panel = $"../PreguntasPanel"
+								# 🔥 Caso especial: Podio de vida extra
+								if category == "Health":
+												var preguntas_panel = $"../PreguntasPanel"
 						if preguntas_panel:
 								preguntas_panel.vidas += 1
 								preguntas_panel._update_health_label()


### PR DESCRIPTION
## Summary
- add new dice throw and pawn landing sounds to the shared SFX manager
- trigger the new sounds from the dice roll and podium landing logic
- display a right-aligned hint instructing players to click to roll the die after closing the tutorial overlay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901815a49508333bdbbe285d300db5b