### PR TITLE
Add audio cues and roll prompt for gameplay

### DIFF
--- a/Assets/Dice/Dice.tscn
+++ b/Assets/Dice/Dice.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=9 format=3 uid="uid://bky2qlnu210xn"]
+[gd_scene load_steps=10 format=3 uid="uid://bky2qlnu210xn"]
 
 [ext_resource type="Script" uid="uid://c0gukvfg2yll8" path="res://Assets/Dice/dice.gd" id="1_0gri7"]
 [ext_resource type="ArrayMesh" uid="uid://n7f6x74pg8un" path="res://Assets/Dice/Dice.obj" id="1_y4aql"]
 [ext_resource type="PackedScene" uid="uid://c4pyewax2yche" path="res://Assets/Dice/dice_raycast.tscn" id="3_q0816"]
 [ext_resource type="AudioStream" uid="uid://cipg7yn02u6e4" path="res://UI & Audio/Musica y Audios/audiomass-output.mp3" id="4_ch4jn"]
+[ext_resource type="AudioStream" uid="uid://dlbkkwlcyr0tp" path="res://UI & Audio/Musica y Audios/DiceCollision.mp3" id="6_ry7ap"]
 [ext_resource type="Script" uid="uid://nkdntcfagla6" path="res://Assets/Dice/audio_stream_player.gd" id="5_ch4jn"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_q0816"]
@@ -60,5 +61,9 @@ opposite_side = 1
 stream = ExtResource("4_ch4jn")
 volume_db = 7.889
 script = ExtResource("5_ch4jn")
+
+[node name="DiceThrowSound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("6_ry7ap")
+volume_db = -3.0
 
 [connection signal="sleeping_state_changed" from="." to="." method="_on_sleeping_state_changed"]

--- a/Assets/Dice/dice.gd
+++ b/Assets/Dice/dice.gd
@@ -3,6 +3,7 @@ extends RigidBody3D
 @onready var raycasts = $Raycasts.get_children()
 @onready var pawn := $"../Player"
 @onready var collision_sound: AudioStreamPlayer = $"Dice sound"
+@onready var throw_sound: AudioStreamPlayer = $"DiceThrowSound"
 @onready var preguntas_panel = $"../PreguntasPanel" # reference to the question panel
 
 var start_pos
@@ -45,17 +46,23 @@ func _input(event):
 		_roll()
 
 func _roll():
-	# Reset state
-	is_rolling = true
-	set_sleeping(false)
-	freeze = false
-	can_emit = true
-	centering = true
-	linear_velocity = Vector3.ZERO
-	angular_velocity = Vector3.ZERO
+        # Reset state
+        is_rolling = true
+        set_sleeping(false)
+        freeze = false
+        can_emit = true
+        centering = true
+        linear_velocity = Vector3.ZERO
+        angular_velocity = Vector3.ZERO
 
-	# Random initial rotation
-	var axis = Vector3(randf(), randf(), randf()).normalized()
+        if throw_sound:
+                if throw_sound.playing:
+                        throw_sound.stop()
+                throw_sound.pitch_scale = randf_range(0.95, 1.05)
+                throw_sound.play()
+
+        # Random initial rotation
+        var axis = Vector3(randf(), randf(), randf()).normalized()
 	var angle = randf_range(0, TAU)
 	self.set_transform(Transform3D(Basis(axis, angle), global_position))
 	set_sleeping(false)  # Force wake AFTER changing transform

--- a/Assets/Dice/dice.gd
+++ b/Assets/Dice/dice.gd
@@ -46,23 +46,23 @@ func _input(event):
 		_roll()
 
 func _roll():
-        # Reset state
-        is_rolling = true
-        set_sleeping(false)
-        freeze = false
-        can_emit = true
-        centering = true
-        linear_velocity = Vector3.ZERO
-        angular_velocity = Vector3.ZERO
+	# Reset state
+	is_rolling = true
+	set_sleeping(false)
+	freeze = false
+	can_emit = true
+	centering = true
+	linear_velocity = Vector3.ZERO
+	angular_velocity = Vector3.ZERO
 
-        if throw_sound:
-                if throw_sound.playing:
-                        throw_sound.stop()
-                throw_sound.pitch_scale = randf_range(0.95, 1.05)
-                throw_sound.play()
+	if throw_sound:
+		if throw_sound.playing:
+			throw_sound.stop()
+	throw_sound.pitch_scale = randf_range(0.95, 1.05)
+	throw_sound.play()
 
-        # Random initial rotation
-        var axis = Vector3(randf(), randf(), randf()).normalized()
+		# Random initial rotation
+	var axis = Vector3(randf(), randf(), randf()).normalized()
 	var angle = randf_range(0, TAU)
 	self.set_transform(Transform3D(Basis(axis, angle), global_position))
 	set_sleeping(false)  # Force wake AFTER changing transform

--- a/Assets/sfx/dice throw.mp3.import
+++ b/Assets/sfx/dice throw.mp3.import
@@ -1,0 +1,19 @@
+[remap]
+
+importer="mp3"
+type="AudioStreamMP3"
+uid="uid://18mwkd1211ot"
+path="res://.godot/imported/dice throw.mp3-e454997093b751950df1077b049c1bcc.mp3str"
+
+[deps]
+
+source_file="res://Assets/sfx/dice throw.mp3"
+dest_files=["res://.godot/imported/dice throw.mp3-e454997093b751950df1077b049c1bcc.mp3str"]
+
+[params]
+
+loop=false
+loop_offset=0
+bpm=0
+beat_count=0
+bar_beats=4

--- a/Assets/sfx/pawn land.mp3.import
+++ b/Assets/sfx/pawn land.mp3.import
@@ -1,0 +1,19 @@
+[remap]
+
+importer="mp3"
+type="AudioStreamMP3"
+uid="uid://bp3jg0rv285ig"
+path="res://.godot/imported/pawn land.mp3-64a22f7612b29281a4d3f345b95209e6.mp3str"
+
+[deps]
+
+source_file="res://Assets/sfx/pawn land.mp3"
+dest_files=["res://.godot/imported/pawn land.mp3-64a22f7612b29281a4d3f345b95209e6.mp3str"]
+
+[params]
+
+loop=false
+loop_offset=0
+bpm=0
+beat_count=0
+bar_beats=4

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -75,12 +75,12 @@ func _process(delta: float) -> void:
 		pawn.global_position = pos
 
 func _on_pawn_finished_moving(_landed_spot: Node) -> void:
-        if landing_sound:
-                if landing_sound.playing:
-                        landing_sound.stop()
-                landing_sound.pitch_scale = 1.1
-                landing_sound.play()
-        var vfx = preload("res://Assets/Vfx/PawnLandingVfx.tscn").instantiate()
-        get_tree().current_scene.add_child(vfx)
-        vfx.global_position = global_position   # pawn position
-        print("vfx")
+		if landing_sound:
+				if landing_sound.playing:
+						landing_sound.stop()
+				landing_sound.pitch_scale = 1.1
+				landing_sound.play()
+		var vfx = preload("res://Assets/Vfx/PawnLandingVfx.tscn").instantiate()
+		get_tree().current_scene.add_child(vfx)
+		vfx.global_position = global_position   # pawn position
+		print("vfx")

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -4,6 +4,7 @@ signal pawn_finished_moving(spot: Marker3D)
 
 @onready var pawn: CharacterBody3D = self
 @onready var dice := $"../Dice"
+@onready var landing_sound: AudioStreamPlayer = $"LandingSound"
 @export var game_spaces: Array[Marker3D]
 
 var pawn_landed: bool = true
@@ -74,7 +75,12 @@ func _process(delta: float) -> void:
 		pawn.global_position = pos
 
 func _on_pawn_finished_moving(_landed_spot: Node) -> void:
-	var vfx = preload("res://Assets/Vfx/PawnLandingVfx.tscn").instantiate()
-	get_tree().current_scene.add_child(vfx)
-	vfx.global_position = global_position   # pawn position
-	print("vfx")
+        if landing_sound:
+                if landing_sound.playing:
+                        landing_sound.stop()
+                landing_sound.pitch_scale = 1.1
+                landing_sound.play()
+        var vfx = preload("res://Assets/Vfx/PawnLandingVfx.tscn").instantiate()
+        get_tree().current_scene.add_child(vfx)
+        vfx.global_position = global_position   # pawn position
+        print("vfx")

--- a/Player/player.tscn
+++ b/Player/player.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://cq0kl3xg7kong"]
+[gd_scene load_steps=5 format=3 uid="uid://cq0kl3xg7kong"]
 
 [ext_resource type="Script" uid="uid://c1vctitsj6loy" path="res://Player/player.gd" id="1_4ntmi"]
 [ext_resource type="PackedScene" uid="uid://c8g3ywh6lvn6m" path="res://Player/Pawn.glb" id="1_l8h54"]
+[ext_resource type="AudioStream" uid="uid://dlbkkwlcyr0tp" path="res://UI & Audio/Musica y Audios/DiceCollision.mp3" id="3_hl6us"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_l8h54"]
 size = Vector3(2.53223, 4.69348, 2.58984)
@@ -10,6 +11,10 @@ size = Vector3(2.53223, 4.69348, 2.58984)
 script = ExtResource("1_4ntmi")
 
 [node name="Pawn" parent="." instance=ExtResource("1_l8h54")]
+
+[node name="LandingSound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("3_hl6us")
+volume_db = -4.0
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.37506, 0)

--- a/levels/main.gd
+++ b/levels/main.gd
@@ -25,6 +25,7 @@ const HEALTH_FLASH_ALPHA = 0.3
 @onready var score_label: Label = $Score
 @onready var health_label: Label = $Health
 @onready var dice: Node = $Dice
+@onready var roll_prompt_label: Label = $"RollPromptLayer/RollPromptLabel"
 @onready var victory_overlay: CanvasLayer = $VictoryOverlay
 @onready var victory_title_label: Label = $"VictoryOverlay/CenterContainer/Panel/VBoxContainer/TitleLabel"
 @onready var victory_message_label: Label = $"VictoryOverlay/CenterContainer/Panel/VBoxContainer/MessageLabel"
@@ -45,6 +46,7 @@ var overlay_tween: Tween
 var light_tween: Tween
 var extra_life_tween: Tween
 var defeat_forces_menu: bool = false
+var roll_prompt_active: bool = false
 
 func _ready() -> void:
 	RenderingServer.force_draw(true)
@@ -99,13 +101,17 @@ func _ready() -> void:
 				intro_overlay.call_deferred("show_intro", "Modo fácil", "[center]Un recorrido relajado para practicar las categorías del juego sin presión.\nLanza el dado, aprende a tu ritmo y experimenta cada tema con calma.[/center]")
 		defeat_forces_menu = false
 
-		_apply_scene_color("default", 0.0)
-		_set_extra_life_label_visible(false)
+                _apply_scene_color("default", 0.0)
+                _set_extra_life_label_visible(false)
+        if roll_prompt_label:
+                roll_prompt_label.visible = false
 
 func _input(event: InputEvent) -> void:
-	if event.is_action_pressed("ui_cancel"):
-		if guide_overlay and guide_overlay.is_open:
-			guide_overlay.close()
+        if roll_prompt_active and event.is_action_pressed("LeftClick"):
+                _hide_roll_prompt()
+        if event.is_action_pressed("ui_cancel"):
+                if guide_overlay and guide_overlay.is_open:
+                        guide_overlay.close()
 		elif config_overlay and config_overlay.is_open:
 			config_overlay.close()
 		else:
@@ -265,8 +271,21 @@ func _on_config_overlay_restart_requested() -> void:
 		get_tree().reload_current_scene()
 
 func _on_intro_overlay_closed() -> void:
-		if config_button:
-				config_button.grab_focus()
+        if config_button:
+                config_button.grab_focus()
+        _show_roll_prompt()
+
+func _show_roll_prompt() -> void:
+        if not roll_prompt_label:
+                return
+        roll_prompt_label.visible = true
+        roll_prompt_active = true
+
+func _hide_roll_prompt() -> void:
+        if not roll_prompt_label:
+                return
+        roll_prompt_label.visible = false
+        roll_prompt_active = false
 
 func _apply_scene_color(category: String, alpha: float) -> void:
 	var base_color = CATEGORY_COLORS.get(category, CATEGORY_COLORS["default"])

--- a/levels/main.gd
+++ b/levels/main.gd
@@ -100,18 +100,17 @@ func _ready() -> void:
 				intro_overlay.intro_closed.connect(_on_intro_overlay_closed)
 				intro_overlay.call_deferred("show_intro", "Modo fácil", "[center]Un recorrido relajado para practicar las categorías del juego sin presión.\nLanza el dado, aprende a tu ritmo y experimenta cada tema con calma.[/center]")
 		defeat_forces_menu = false
-
-                _apply_scene_color("default", 0.0)
-                _set_extra_life_label_visible(false)
-        if roll_prompt_label:
-                roll_prompt_label.visible = false
+		_apply_scene_color("default", 0.0)
+		_set_extra_life_label_visible(false)
+		if roll_prompt_label:
+				roll_prompt_label.visible = false
 
 func _input(event: InputEvent) -> void:
-        if roll_prompt_active and event.is_action_pressed("LeftClick"):
-                _hide_roll_prompt()
-        if event.is_action_pressed("ui_cancel"):
-                if guide_overlay and guide_overlay.is_open:
-                        guide_overlay.close()
+	if roll_prompt_active and event.is_action_pressed("LeftClick"):
+		_hide_roll_prompt()
+		if event.is_action_pressed("ui_cancel"):
+				if guide_overlay and guide_overlay.is_open:
+						guide_overlay.close()
 		elif config_overlay and config_overlay.is_open:
 			config_overlay.close()
 		else:
@@ -271,21 +270,21 @@ func _on_config_overlay_restart_requested() -> void:
 		get_tree().reload_current_scene()
 
 func _on_intro_overlay_closed() -> void:
-        if config_button:
-                config_button.grab_focus()
-        _show_roll_prompt()
+		if config_button:
+				config_button.grab_focus()
+		_show_roll_prompt()
 
 func _show_roll_prompt() -> void:
-        if not roll_prompt_label:
-                return
-        roll_prompt_label.visible = true
-        roll_prompt_active = true
+		if not roll_prompt_label:
+				return
+		roll_prompt_label.visible = true
+		roll_prompt_active = true
 
 func _hide_roll_prompt() -> void:
-        if not roll_prompt_label:
-                return
-        roll_prompt_label.visible = false
-        roll_prompt_active = false
+		if not roll_prompt_label:
+				return
+		roll_prompt_label.visible = false
+		roll_prompt_active = false
 
 func _apply_scene_color(category: String, alpha: float) -> void:
 	var base_color = CATEGORY_COLORS.get(category, CATEGORY_COLORS["default"])

--- a/levels/main.tscn
+++ b/levels/main.tscn
@@ -215,6 +215,31 @@ text = "Vidas: 3"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="RollPromptLayer" type="CanvasLayer" parent="."]
+layer = 3
+
+[node name="RollPromptLabel" type="Label" parent="RollPromptLayer"]
+visible = false
+anchors_preset = -1
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+offset_left = -540.0
+offset_top = 140.0
+offset_right = -40.0
+offset_bottom = 240.0
+grow_horizontal = 0
+grow_vertical = 0
+theme = ExtResource("7_6et1j")
+theme_override_colors/font_color = Color(0.909804, 0.968627, 0.937255, 1)
+theme_override_styles/normal = ExtResource("8_etqu2")
+theme_override_font_sizes/font_size = 32
+text = "Dé click en cualquier lugar de la pantalla para tirar el dado"
+horizontal_alignment = 2
+vertical_alignment = 1
+autowrap_mode = 2
+
 [node name="ColorOverlay" type="CanvasLayer" parent="."]
 layer = -5
 


### PR DESCRIPTION
## Summary
- add a dedicated dice throw audio player and trigger it whenever the die is rolled
- add a landing sound to the pawn and play it after each move completes
- display a roll prompt label once the intro overlay closes and hide it after the first click

## Testing
- not run (Godot project)


------
https://chatgpt.com/codex/tasks/task_e_6901815a49508333bdbbe285d300db5b