### PR TITLE
Add dice throw and pawn landing feedback

### DIFF
--- a/Assets/Dice/Dice.tscn
+++ b/Assets/Dice/Dice.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://bky2qlnu210xn"]
+[gd_scene load_steps=10 format=3 uid="uid://bky2qlnu210xn"]
 
 [ext_resource type="Script" uid="uid://c0gukvfg2yll8" path="res://Assets/Dice/dice.gd" id="1_0gri7"]
 [ext_resource type="ArrayMesh" uid="uid://n7f6x74pg8un" path="res://Assets/Dice/Dice.obj" id="1_y4aql"]
 [ext_resource type="PackedScene" uid="uid://c4pyewax2yche" path="res://Assets/Dice/dice_raycast.tscn" id="3_q0816"]
+[ext_resource type="AudioStream" uid="uid://dlbkkwlcyr0tp" path="res://UI & Audio/Musica y Audios/DiceCollision.mp3" id="4_ofi3l"]
 [ext_resource type="AudioStream" uid="uid://cipg7yn02u6e4" path="res://UI & Audio/Musica y Audios/audiomass-output.mp3" id="4_ch4jn"]
 [ext_resource type="Script" uid="uid://nkdntcfagla6" path="res://Assets/Dice/audio_stream_player.gd" id="5_ch4jn"]
 
@@ -60,5 +61,8 @@ opposite_side = 1
 stream = ExtResource("4_ch4jn")
 volume_db = 7.889
 script = ExtResource("5_ch4jn")
+
+[node name="ThrowSound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("4_ofi3l")
 
 [connection signal="sleeping_state_changed" from="." to="." method="_on_sleeping_state_changed"]

--- a/Assets/Dice/dice.gd
+++ b/Assets/Dice/dice.gd
@@ -3,6 +3,7 @@ extends RigidBody3D
 @onready var raycasts = $Raycasts.get_children()
 @onready var pawn := $"../Player"
 @onready var collision_sound: AudioStreamPlayer = $"Dice sound"
+@onready var throw_sound: AudioStreamPlayer = $"ThrowSound"
 @onready var preguntas_panel = $"../PreguntasPanel" # reference to the question panel
 
 var start_pos
@@ -53,6 +54,10 @@ func _roll():
 	centering = true
 	linear_velocity = Vector3.ZERO
 	angular_velocity = Vector3.ZERO
+
+	if throw_sound:
+		throw_sound.stop()
+		throw_sound.play()
 
 	# Random initial rotation
 	var axis = Vector3(randf(), randf(), randf()).normalized()

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -4,6 +4,7 @@ signal pawn_finished_moving(spot: Marker3D)
 
 @onready var pawn: CharacterBody3D = self
 @onready var dice := $"../Dice"
+@onready var landing_sound: AudioStreamPlayer = $"LandingSound"
 @export var game_spaces: Array[Marker3D]
 
 var pawn_landed: bool = true
@@ -74,6 +75,9 @@ func _process(delta: float) -> void:
 		pawn.global_position = pos
 
 func _on_pawn_finished_moving(_landed_spot: Node) -> void:
+	if landing_sound:
+		landing_sound.stop()
+		landing_sound.play()
 	var vfx = preload("res://Assets/Vfx/PawnLandingVfx.tscn").instantiate()
 	get_tree().current_scene.add_child(vfx)
 	vfx.global_position = global_position   # pawn position

--- a/Player/player.tscn
+++ b/Player/player.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://cq0kl3xg7kong"]
+[gd_scene load_steps=5 format=3 uid="uid://cq0kl3xg7kong"]
 
 [ext_resource type="Script" uid="uid://c1vctitsj6loy" path="res://Player/player.gd" id="1_4ntmi"]
 [ext_resource type="PackedScene" uid="uid://c8g3ywh6lvn6m" path="res://Player/Pawn.glb" id="1_l8h54"]
+[ext_resource type="AudioStream" uid="uid://dlbkkwlcyr0tp" path="res://UI & Audio/Musica y Audios/DiceCollision.mp3" id="3_e7yi4"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_l8h54"]
 size = Vector3(2.53223, 4.69348, 2.58984)
@@ -14,3 +15,6 @@ script = ExtResource("1_4ntmi")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.37506, 0)
 shape = SubResource("BoxShape3D_l8h54")
+
+[node name="LandingSound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("3_e7yi4")

--- a/levels/main.gd
+++ b/levels/main.gd
@@ -36,6 +36,7 @@ const HEALTH_FLASH_ALPHA = 0.3
 @onready var config_button: BaseButton = $"ConfigButtonLayer/ConfigButtonRoot/ConfigButton"
 @onready var guide_overlay: CanvasLayer = $GuideOverlay
 @onready var guide_button: BaseButton = $"GuideButtonLayer/GuideButtonRoot/GuideButton"
+@onready var dice_instruction_label: Label = $"HUDMessages/DiceInstructionLabel"
 
 var default_light_color: Color = Color.WHITE
 var default_floor_color: Color = Color.WHITE
@@ -112,6 +113,9 @@ func _input(event: InputEvent) -> void:
 			_show_exit_dialog()
 	elif victory_overlay and victory_overlay.visible and event.is_action_pressed("ui_accept"):
 		_restart_game()
+	elif event.is_action_pressed("LeftClick"):
+		if dice_instruction_label and dice_instruction_label.visible:
+			dice_instruction_label.hide()
 
 func _on_category_reached(category: String) -> void:
 	current_category = category
@@ -265,8 +269,10 @@ func _on_config_overlay_restart_requested() -> void:
 		get_tree().reload_current_scene()
 
 func _on_intro_overlay_closed() -> void:
-		if config_button:
-				config_button.grab_focus()
+	if config_button:
+		config_button.grab_focus()
+	if dice_instruction_label:
+		dice_instruction_label.show()
 
 func _apply_scene_color(category: String, alpha: float) -> void:
 	var base_color = CATEGORY_COLORS.get(category, CATEGORY_COLORS["default"])

--- a/levels/main.tscn
+++ b/levels/main.tscn
@@ -249,6 +249,23 @@ text = "+1 Vida extra!"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="DiceInstructionLabel" type="Label" parent="HUDMessages"]
+visible = false
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -380.0
+offset_top = 220.0
+offset_right = -40.0
+offset_bottom = 320.0
+grow_horizontal = 0
+theme = ExtResource("7_6et1j")
+theme_override_font_sizes/font_size = 32
+text = "Dé click en cualquier lugar de la pantalla para tirar el dado"
+horizontal_alignment = 2
+vertical_alignment = 1
+autowrap_mode = 2
+
 [node name="VictoryOverlay" type="CanvasLayer" parent="."]
 layer = 20
 visible = false


### PR DESCRIPTION
## Summary
- add dedicated throw sound to the dice and trigger it whenever a roll starts
- play a landing sound when the pawn completes its movement onto a podium
- show a right-aligned instruction label after the intro closes and hide it on first click

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902033ef2d4833388e7ead85e5ac103