### PR TITLE
Add audio cues, randomized answers, and guide access

### DIFF
--- a/Assets/Dice/dice.gd
+++ b/Assets/Dice/dice.gd
@@ -37,10 +37,10 @@ func _ready() -> void:
 
 func _input(event):
 	if event.is_action_released("LeftClick") \
-	&& global_position.distance_to(start_pos) < 4 \
-	&& !is_rolling \
-	&& pawn.pawn_landed == true \
-	&& can_roll:   # <-- only roll if allowed
+		&& global_position.distance_to(start_pos) < 4 \
+		&& !is_rolling \
+		&& pawn.pawn_landed == true \
+		&& can_roll:   # <-- only roll if allowed
 		rolled_value = 0
 		_roll()
 
@@ -53,6 +53,7 @@ func _roll():
 	centering = true
 	linear_velocity = Vector3.ZERO
 	angular_velocity = Vector3.ZERO
+	SFX.play_dice_throw()
 
 	# Random initial rotation
 	var axis = Vector3(randf(), randf(), randf()).normalized()

--- a/Assets/sfx/sfx_manager.gd
+++ b/Assets/sfx/sfx_manager.gd
@@ -4,6 +4,8 @@ const CORRECT_STREAM: AudioStream = preload("res://Assets/sfx/correct_answer.mp3
 const WRONG_STREAM: AudioStream = preload("res://Assets/sfx/wrong_answer.mp3")
 const FAILURE_STREAM: AudioStream = preload("res://Assets/sfx/failure.mp3")
 const SUCCESS_STREAM: AudioStream = preload("res://Assets/sfx/success.mp3")
+const DICE_THROW_STREAM: AudioStream = preload("res://Assets/sfx/dice_throw.mp3")
+const PAWN_LAND_STREAM: AudioStream = preload("res://Assets/sfx/pawn_land.mp3")
 const SELECT_STREAMS: Array[AudioStream] = [
 	preload("res://Assets/sfx/select_button1.mp3"),
 	preload("res://Assets/sfx/select_button2.mp3")
@@ -15,6 +17,8 @@ var wrong_player: AudioStreamPlayer
 var failure_player: AudioStreamPlayer
 var success_player: AudioStreamPlayer
 var select_player: AudioStreamPlayer
+var dice_player: AudioStreamPlayer
+var pawn_player: AudioStreamPlayer
 
 func _ready() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
@@ -23,6 +27,8 @@ func _ready() -> void:
 	wrong_player = _create_player("WrongPlayer", WRONG_STREAM, 4)
 	failure_player = _create_player("FailurePlayer", FAILURE_STREAM, 2)
 	success_player = _create_player("SuccessPlayer", SUCCESS_STREAM, 2)
+	dice_player = _create_player("DicePlayer", DICE_THROW_STREAM, 2)
+	pawn_player = _create_player("PawnPlayer", PAWN_LAND_STREAM, 4)
 	var initial_select_stream: AudioStream = SELECT_STREAMS[0] if not SELECT_STREAMS.is_empty() else null
 	select_player = _create_player("SelectPlayer", initial_select_stream, 12)
 	var tree := get_tree()
@@ -42,6 +48,12 @@ func play_failure() -> void:
 func play_success() -> void:
 	_play_stream(success_player, SUCCESS_STREAM)
 
+func play_dice_throw() -> void:
+	_play_stream(dice_player, DICE_THROW_STREAM)
+
+func play_pawn_land() -> void:
+	_play_stream(pawn_player, PAWN_LAND_STREAM, 0.3)
+
 func play_select() -> void:
 	if SELECT_STREAMS.is_empty():
 		return
@@ -58,11 +70,11 @@ func _create_player(player_name: String, stream: AudioStream, polyphony: int) ->
 	add_child(player)
 	return player
 
-func _play_stream(player: AudioStreamPlayer, stream: AudioStream) -> void:
+func _play_stream(player: AudioStreamPlayer, stream: AudioStream, start_position: float = 0.0) -> void:
 	if player == null or stream == null:
 		return
 	player.stream = stream
-	player.play()
+	player.play(start_position)
 
 func _on_node_added(node: Node) -> void:
 	if node == null:

--- a/Documentacion/diseno_juego_modo_facil.md
+++ b/Documentacion/diseno_juego_modo_facil.md
@@ -1,0 +1,130 @@
+# Documento de Funcionamiento del Juego – Modo Fácil
+
+## 1. Resumen ejecutivo
+Este documento describe el funcionamiento completo del modo fácil del juego educativo desarrollado para la Sociedad Colombiana de Anestesiología y Reanimación (SCARE). Se resumen los objetivos pedagógicos, el flujo de juego, las reglas, la interfaz de usuario, los sistemas técnicos principales y los datos gestionados para que cualquier lector pueda comprender, operar y, de ser necesario, mantener el proyecto.
+
+## 2. Contexto del proyecto
+- **Propósito:** Facilitar el repaso de conceptos clave de anestesiología a través de una experiencia lúdica basada en tablero.
+- **Público objetivo:** Profesionales y estudiantes de SCARE que participen en talleres o eventos formativos.
+- **Plataforma:** Godot Engine 4 (proyecto `project.godot`). Se ejecuta como aplicación de escritorio o web exportada.
+- **Estado de referencia:** Escena principal `levels/main.tscn` con sus scripts asociados.
+
+## 3. Visión general del juego
+- **Elevator pitch:** El jugador lanza un dado virtual, avanza un peón sobre podios temáticos y responde preguntas de opción múltiple para acumular puntos y mantener sus vidas.
+- **Objetivos educativos:** Exponer al participante a preguntas cortas distribuidas en categorías médicas. Cada categoría aporta contenido específico y colorimetría asociada (`levels/main.gd`, constante `CATEGORY_COLORS`).
+- **Tono y narrativa:** Experiencia relajada, acompañada por la introducción textual del modo fácil (`UI & Audio/mode_intro_overlay.gd`). No hay narrativa ficcional, sino una ambientación de tablero futurista.
+
+## 4. Flujo de juego
+1. **Inicio y tutorial:**
+   - Se carga la escena `levels/main.tscn`, se muestra la superposición `ModeIntroOverlay` con título, descripción y botón “Comenzar”. Mientras está visible, el árbol está en pausa (`mode_intro_overlay.gd`).
+2. **Indicación inicial:**
+   - Al cerrar la introducción, aparece la etiqueta “Dé click en cualquier lugar de la pantalla para tirar el dado” en la esquina superior derecha (`levels/main.gd`, nodo `HUDMessages/ClickInstructionLabel`). Se oculta automáticamente con el primer clic detectado (`_input`).
+3. **Lanzamiento de dado:**
+   - El jugador hace clic izquierdo sobre el área de juego con el peón en reposo para accionar el dado (`Assets/Dice/dice.gd`, método `_input`).
+4. **Movimiento del peón:**
+   - El peón se desplaza salto a salto según el número obtenido (`Player/player.gd`, `_start_next_jump` y `_process`). Cada aterrizaje reproduce un efecto de sonido y partículas.
+5. **Encuentro con podio:**
+   - El script `levels/spots.gd` detecta el podio final y emite la categoría correspondiente o el evento de vida extra para `PreguntasPanel`.
+6. **Pregunta y resolución:**
+   - `UI & Audio/preguntas_panel.gd` muestra una pregunta aleatoria de la categoría, administra temporizador de 45 segundos, califica la respuesta, actualiza puntuación y vidas y reproduce retroalimentación audiovisual.
+7. **Estado del juego:**
+   - La partida continúa en bucle (lanzar dado → moverse → preguntar) hasta alcanzar 15 puntos (victoria) o perder todas las vidas (derrota). Se muestra `VictoryOverlay` con mensajes contextuales (`levels/main.gd`, `_show_end_overlay`).
+8. **Post-juego:**
+   - Se puede reiniciar la partida o volver al menú principal (`_restart_game`, `_return_to_main_menu`). Si la derrota ocurre por falta de vidas, se fuerza el regreso al menú para reiniciar el flujo.
+
+## 5. Reglas y mecánicas
+- **Lanzamiento del dado:**
+  - Solo se permite tirar cuando el peón ha aterrizado y no hay panel de preguntas abierto (`dice.gd`, bandera `can_roll`).
+  - El dado aplica fuerza y torque aleatorios; cuando se detiene, determina el valor final mediante raycasts (`Dice.tscn`, grupo `Raycasts`).
+- **Movimiento del peón:**
+  - El peón recorre secuencialmente los `Marker3D` definidos en `Player/player.tscn` (`@export var game_spaces`).
+  - Cada salto describe una parábola suave y bloquea nuevas tiradas hasta finalizar.
+- **Podios y categorías:**
+  - Los podios se instancian aleatoriamente al inicio excluyendo repeticiones consecutivas. Los puestos 10 y 20 garantizan la categoría “Health” (vida extra).
+  - Al aterrizar, `levels/spots.gd` determina la categoría mediante la metadata del podio e invoca `mostrar_pregunta_de_categoria` del panel.
+- **Preguntas:**
+  - Cada categoría tiene un conjunto de preguntas con opciones y retroalimentación (`UI & Audio/preguntas_etapa_1.json`).
+  - Las preguntas usadas se retiran temporalmente para evitar repeticiones hasta agotar la lista, momento en el cual se reinicia el conjunto (`preguntas_panel.gd`, `_cargar_preguntas`).
+  - Las respuestas correctas otorgan un punto; las incorrectas o el tiempo agotado consumen una vida.
+- **Vidas y vida extra:**
+  - Se inicia con 3 vidas (`preguntas_panel.gd`, variable `vidas`).
+  - El podio “Health” suma una vida hasta un máximo no limitado explícitamente y muestra un toast informativo (`levels/main.gd`, `_show_extra_life_toast`).
+  - Sin vidas restantes, se dispara derrota y se bloquea la interacción hasta escoger reinicio o menú (`_game_over`, `_lock_gameplay`).
+- **Condición de victoria:**
+  - Alcanzar 15 puntos detona `victoria_alcanzada`, detiene el flujo y muestra el panel final.
+
+## 6. Interfaz de usuario y experiencia
+- **Tablero 3D:** Escena `levels/main.tscn` combina componentes 3D (tablero, luz, podios, peón, dado) con HUD 2D.
+- **HUD:** Etiquetas `Score` y `Health` muestran progreso y vidas con colorimetría adaptativa según la categoría activa (`_update_ui_colors`).
+- **Panel de preguntas:** CanvasLayer con panel informativo, carta de pregunta y botones de respuesta. Incluye cronómetro con cambios de color, iconografía por categoría y pistas de continuación (`preguntas_panel.tscn`).
+- **Superposiciones:**
+  - `ModeIntroOverlay`: presentación del modo, pausable.
+  - `GuideOverlay`: acceso a guía rápida desde botón lateral (`guide_overlay.tscn`).
+  - `ConfigOverlay`: opciones de configuración y accesos a menú/reinicio (`config_overlay.tscn`).
+  - `VictoryOverlay`: resumen de victoria/derrota con botones de acción.
+  - `ExitConfirmDialog`: confirma salida al menú principal.
+- **Indicadores temporales:** Mensaje de vida extra y texto de instrucción inicial se gestionan mediante tweens y flags para evitar repeticiones.
+
+## 7. Diseño audiovisual
+- **Música y ambientación:** Archivos en `UI & Audio/Musica y Audios/` controlan música de fondo (no gestionados desde los scripts listados, dependerá de la escena principal si se habilita).
+- **Efectos de sonido clave:**
+  - Lanzamiento del dado (`Assets/Dice/dice.gd`, nodo `ThrowSound`).
+  - Golpes del dado durante colisiones (`Dice sound`).
+  - Aterrizaje del peón (`Player/player.tscn`, `LandingSound`).
+  - Respuestas correctas/incorrectas, victoria y derrota (`Assets/sfx/sfx_manager.gd`).
+  - Selección de botones: sonido aleatorio entre variaciones (`play_select`).
+- **Retroalimentación visual:**
+  - Cambios de color en piso, luz y overlays según categoría (`levels/main.gd`, `_apply_scene_color`).
+  - Partículas de aterrizaje (`Assets/Vfx/PawnLandingVfx.tscn`).
+  - Animaciones de entrada del panel de preguntas y cronómetro parpadeante.
+
+## 8. Arquitectura técnica
+- **Escena raíz (`levels/main.tscn`):** Nodo `Node` con subárbol para ambiente 3D, HUD y superposiciones. Script `levels/main.gd` gestiona señales, cambios de color, flujos de victoria/derrota y coordinación general.
+- **Peón (`Player/player.tscn` + `player.gd`):** `CharacterBody3D` con ruta de marcadores exportada y señales para avisar al sistema de podios.
+- **Dado (`Assets/Dice/Dice.tscn` + `dice.gd`):** `RigidBody3D` con raycasts para identificar la cara resultante y audio propio.
+- **Podios (`Assets/Podium/*.tscn`):** Instanciados dinámicamente por `levels/spots.gd`, que también emite las señales `category_reached` y `extra_life_awarded`.
+- **Panel de preguntas (`UI & Audio/preguntas_panel.tscn` + `preguntas_panel.gd`):** Controla ciclo de preguntas, cronómetro, puntuación y vidas.
+- **Gestor de SFX (`Assets/sfx/sfx_manager.gd`):** Nodo autoload (consultar `project.godot` → sección `autoload`) responsable de reproducir efectos globales y conectar botones.
+- **Overlays de guía y configuración:** Scripts `guide_overlay.gd` y `config_overlay.gd` proporcionan apertura/cierre, con señales `overlay_closed`, `menu_requested` y `restart_requested` atendidas desde `levels/main.gd`.
+
+## 9. Datos y telemetría
+- **Datos manejados:**
+  - Puntaje (`puntos`) y vidas (`vidas`) almacenados en memoria durante la sesión.
+  - Historial de preguntas usadas para evitar repeticiones inmediatas.
+  - Estado del tablero (categoría actual, vidas extras otorgadas).
+- **Persistencia:** No se guarda información de manera permanente ni se envían datos a servidores externos. Al reiniciar o volver al menú principal, todo el progreso se restablece.
+- **Privacidad:** Sin recopilación de datos personales ni métricas; cumplimiento implícito con requisitos de privacidad al no almacenar información sensible.
+
+## 10. Contenido y localización
+- **Texto:** Todos los textos de la interfaz están en español, incluidos tutorial, mensajes de overlay y retroalimentación.
+- **Preguntas:** Archivo JSON `UI & Audio/preguntas_etapa_1.json` organiza preguntas por categoría con campos `texto`, `opciones`, `respuesta_correcta` y `retroalimentacion`.
+- **Iconografía:** Asociada a cada categoría en `Assets/Icons/*.svg` y cargada a través del diccionario `icon_map`.
+- **Mensajes dinámicos:** Etiquetas de victoria, derrota, vida extra e instrucciones iniciales generadas desde `levels/main.gd`.
+
+## 11. Pruebas y validación
+- **Pruebas manuales recomendadas:**
+  - Verificar que el tutorial pause el juego y que la instrucción de clic inicial aparezca y desaparezca correctamente.
+  - Lanzar el dado múltiples veces para confirmar comportamiento físico y audio.
+  - Probar respuestas correctas, incorrectas y expiración del tiempo para validar cambios de puntuación/vidas y señales de victoria/derrota.
+  - Asegurar que los podios “Health” otorguen vida extra y muestren el toast.
+  - Revisar accesos a guía, configuración y diálogo de salida durante una partida activa.
+- **Automatización:** No se incluyen pruebas automatizadas. Se sugiere evaluar la viabilidad de tests de GUT o integración en futuras iteraciones.
+
+## 12. Despliegue y configuración
+- **Construcción:** Utilizar los presets definidos en `export_presets.cfg` para generar builds. Confirmar dependencias de assets multimedia antes de exportar.
+- **Configuración en tiempo de ejecución:**
+  - Controles vía ratón/entrada táctil para lanzar dado y seleccionar respuestas.
+  - El menú de configuración ofrece accesos a reinicio y retorno al menú principal.
+- **Requerimientos:** Godot 4.x para edición; hardware capaz de renderizar escenas 3D moderadas.
+
+## 13. Apéndices
+- **Lista de escenas clave:**
+  - `levels/main.tscn`, `levels/exam_main.tscn` (modo examen, fuera de alcance de este documento pero reutiliza componentes).
+  - `Player/player.tscn`, `Assets/Dice/Dice.tscn`, `UI & Audio/preguntas_panel.tscn`.
+- **Recursos de audio destacados:**
+  - `Assets/sfx/correct_answer.mp3`, `Assets/sfx/wrong_answer.mp3`, `Assets/sfx/success.mp3`, `Assets/sfx/failure.mp3`.
+  - `Assets/Dice/throw_sound.ogg` (según configuración de la escena) y sonidos de colisión.
+- **Glosario:**
+  - **Podio:** Casilla del tablero que detona la visualización de una pregunta y define su categoría.
+  - **HUD:** Capa de interfaz 2D que muestra puntuación, vidas y mensajes auxiliares.
+  - **Overlay:** Superposición de interfaz que bloquea temporalmente la interacción principal.

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -52,6 +52,7 @@ func _process(delta: float) -> void:
 			jump_t = 1.0
 			is_jumping = false
 			pawn.global_position = jump_end
+			SFX.play_pawn_land()
 
 			# advance place for the NEXT step/turn
 			place = (place + 1) % place_number

--- a/UI & Audio/Musica y Audios/musica_de_fondo.tscn
+++ b/UI & Audio/Musica y Audios/musica_de_fondo.tscn
@@ -4,3 +4,4 @@
 
 [node name="MusicaDeFondo" type="AudioStreamPlayer2D"]
 script = ExtResource("1_86e2m")
+bus = "MusicaDeFondo"

--- a/UI & Audio/Pantalla de Inicio/music_control.gd
+++ b/UI & Audio/Pantalla de Inicio/music_control.gd
@@ -14,6 +14,7 @@ func _ready():
 	var volumen = cargar_volumen()
 	value = volumen
 	AudioServer.set_bus_volume_db(audio_bus_id, linear_to_db(volumen))
+	value_changed.connect(_on_value_changed)
 
 func _on_value_changed(value: float) -> void:
 	if audio_bus_id == -1:

--- a/UI & Audio/Pantalla de Inicio/pantalla_de_incio.gd
+++ b/UI & Audio/Pantalla de Inicio/pantalla_de_incio.gd
@@ -3,6 +3,9 @@ extends Control
 # Musica De el juego
 var sonido_fondo := preload("res://UI & Audio/Musica y Audios/main_music.mp3")
 
+@onready var guide_overlay: CanvasLayer = $GuideOverlay
+@onready var enciclopedia_button: Button = $"VBoxContainer/Enciclopedia"
+
 func _ready():
 	# Make sure we assign the right stream
 	if MusicaDeFondo.stream != sonido_fondo:
@@ -16,6 +19,9 @@ func _ready():
 	if not MusicaDeFondo.playing:
 		MusicaDeFondo.play()
 
+	if guide_overlay:
+		guide_overlay.overlay_closed.connect(_on_guide_overlay_closed)
+
 
 # Jugar redirecciona a la escena de escoger modos
 func _on_play_pressed():
@@ -28,3 +34,13 @@ func _on_configuracion_pressed():
 
 func _on_salir_pressed():
 	get_tree().quit()
+
+
+func _on_enciclopedia_pressed():
+	if guide_overlay:
+		guide_overlay.open()
+
+
+func _on_guide_overlay_closed() -> void:
+	if enciclopedia_button:
+		enciclopedia_button.grab_focus()

--- a/UI & Audio/Pantalla de Inicio/pantalla_de_incio.tscn
+++ b/UI & Audio/Pantalla de Inicio/pantalla_de_incio.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://cp1qd8tqy1w7l"]
+[gd_scene load_steps=7 format=3 uid="uid://cp1qd8tqy1w7l"]
 
 [ext_resource type="Script" uid="uid://ccj15wq3hm0pw" path="res://UI & Audio/Pantalla de Inicio/pantalla_de_incio.gd" id="1_5je2x"]
 [ext_resource type="Theme" uid="uid://cjifprtp6t2w7" path="res://UI & Audio/Themes/Title.tres" id="1_muksq"]
 [ext_resource type="Texture2D" uid="uid://b7cnp8cd1dmjf" path="res://Assets/backgroundimaged.png" id="2_6m0mc"]
 [ext_resource type="FontFile" uid="uid://danw3x5216ldp" path="res://Assets/House of cards W03 Regular.ttf" id="4_4uw2f"]
 [ext_resource type="StyleBox" uid="uid://c4p046705uewg" path="res://UI & Audio/Themes/stylebox1.tres" id="5_j7hxy"]
+[ext_resource type="PackedScene" uid="uid://cv2s4t6rclgui" path="res://UI & Audio/guide_overlay.tscn" id="6_p9k6t"]
 
 [node name="PantallaDeIncio" type="Control"]
 layout_mode = 3
@@ -67,6 +68,12 @@ theme = ExtResource("1_muksq")
 theme_type_variation = &"FlatButton"
 text = "Configuración"
 
+[node name="Enciclopedia" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme = ExtResource("1_muksq")
+theme_type_variation = &"FlatButton"
+text = "Enciclopedia Hipertermia Maligna"
+
 [node name="Salir" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 theme = ExtResource("1_muksq")
@@ -110,6 +117,9 @@ horizontal_alignment = 1
 vertical_alignment = 1
 justification_flags = 35
 
+[node name="GuideOverlay" parent="." instance=ExtResource("6_p9k6t")]
+
 [connection signal="pressed" from="VBoxContainer/Play" to="." method="_on_play_pressed"]
 [connection signal="pressed" from="VBoxContainer/Configuracion" to="." method="_on_configuracion_pressed"]
+[connection signal="pressed" from="VBoxContainer/Enciclopedia" to="." method="_on_enciclopedia_pressed"]
 [connection signal="pressed" from="VBoxContainer/Salir" to="." method="_on_salir_pressed"]

--- a/UI & Audio/config_overlay.gd
+++ b/UI & Audio/config_overlay.gd
@@ -23,6 +23,7 @@ func _ready() -> void:
 		stored_volume = max(volume_slider.value, 0.05)
 		_update_slider_info(volume_slider.value)
 		volume_slider.value_changed.connect(_on_volume_value_changed)
+		_apply_music_volume(volume_slider.value)
 	if mute_toggle:
 		mute_toggle.button_pressed = volume_slider.value <= 0.001
 	if dimmer:
@@ -94,6 +95,7 @@ func _on_mute_toggle_toggled(button_pressed: bool) -> void:
 
 func _on_volume_value_changed(value: float) -> void:
 	_update_slider_info(value)
+	_apply_music_volume(value)
 	if value > 0.001:
 		stored_volume = value
 	if mute_toggle and not ignore_toggle_update:
@@ -116,3 +118,14 @@ func _on_dimmer_gui_input(event: InputEvent) -> void:
 		_on_close_button_pressed()
 		if get_viewport():
 			get_viewport().set_input_as_handled()
+
+func _apply_music_volume(value: float) -> void:
+	var clamped_value: float = clamp(value, 0.0, 1.0)
+	var db: float = -80.0
+	if clamped_value > 0.0:
+		db = linear_to_db(clamped_value)
+	var bus_index: int = AudioServer.get_bus_index("MusicaDeFondo")
+	if bus_index >= 0:
+		AudioServer.set_bus_volume_db(bus_index, db)
+	if MusicaDeFondo:
+		MusicaDeFondo.volume_db = db

--- a/UI & Audio/config_overlay.tscn
+++ b/UI & Audio/config_overlay.tscn
@@ -70,6 +70,7 @@ max_value = 1.0
 step = 0.05
 value = 1.0
 script = ExtResource("3_v9n24")
+audio_bus_name = "MusicaDeFondo"
 
 [node name="ButtonGrid" type="GridContainer" parent="CenterContainer/Panel/VBoxContainer"]
 layout_mode = 2

--- a/UI & Audio/preguntas_panel_examen.gd
+++ b/UI & Audio/preguntas_panel_examen.gd
@@ -51,10 +51,22 @@ func _mostrar_pregunta_examen(p: Dictionary, cat: String) -> void:
 	label_pregunta.text = p.get("texto", "")
 	_hide_timeout_effect()
 	var opciones: Array = []
+	var correct_index: int = p.get("respuesta_correcta", 0)
+	var correct_text: String = ""
 	if p.has("opciones"):
 		opciones = p["opciones"].duplicate(true)
+		if correct_index >= 0 and correct_index < opciones.size():
+			correct_text = opciones[correct_index]
+		else:
+			correct_index = clamp(correct_index, 0, max(opciones.size() - 1, 0))
+		if opciones.size() > 1:
+			opciones.shuffle()
+		if correct_text != "":
+			correct_index = opciones.find(correct_text)
+		else:
+			correct_index = clamp(correct_index, 0, max(opciones.size() - 1, 0))
 	pregunta_actual["opciones"] = opciones
-	pregunta_actual["respuesta_correcta"] = p.get("respuesta_correcta", 0)
+	pregunta_actual["respuesta_correcta"] = correct_index
 	for i in range(botones.size()):
 		var texto_opcion: String = ""
 		if i < opciones.size():

--- a/levels/main.gd
+++ b/levels/main.gd
@@ -36,6 +36,7 @@ const HEALTH_FLASH_ALPHA = 0.3
 @onready var config_button: BaseButton = $"ConfigButtonLayer/ConfigButtonRoot/ConfigButton"
 @onready var guide_overlay: CanvasLayer = $GuideOverlay
 @onready var guide_button: BaseButton = $"GuideButtonLayer/GuideButtonRoot/GuideButton"
+@onready var click_hint_label: Label = $ClickHintLabel
 
 var default_light_color: Color = Color.WHITE
 var default_floor_color: Color = Color.WHITE
@@ -45,6 +46,7 @@ var overlay_tween: Tween
 var light_tween: Tween
 var extra_life_tween: Tween
 var defeat_forces_menu: bool = false
+var click_hint_active: bool = false
 
 func _ready() -> void:
 	RenderingServer.force_draw(true)
@@ -103,6 +105,8 @@ func _ready() -> void:
 		_set_extra_life_label_visible(false)
 
 func _input(event: InputEvent) -> void:
+	if click_hint_active and event is InputEventMouseButton and event.pressed and event.button_index == MouseButton.MOUSE_BUTTON_LEFT:
+		_hide_click_hint()
 	if event.is_action_pressed("ui_cancel"):
 		if guide_overlay and guide_overlay.is_open:
 			guide_overlay.close()
@@ -261,12 +265,25 @@ func _on_config_overlay_menu_requested() -> void:
 	_show_exit_dialog()
 
 func _on_config_overlay_restart_requested() -> void:
-		defeat_forces_menu = false
-		get_tree().reload_current_scene()
+	defeat_forces_menu = false
+	get_tree().reload_current_scene()
 
 func _on_intro_overlay_closed() -> void:
-		if config_button:
-				config_button.grab_focus()
+	_show_click_hint()
+	if config_button:
+		config_button.grab_focus()
+
+func _show_click_hint() -> void:
+	if not click_hint_label:
+		return
+	click_hint_label.visible = true
+	click_hint_active = true
+
+func _hide_click_hint() -> void:
+	if not click_hint_label:
+		return
+	click_hint_label.visible = false
+	click_hint_active = false
 
 func _apply_scene_color(category: String, alpha: float) -> void:
 	var base_color = CATEGORY_COLORS.get(category, CATEGORY_COLORS["default"])

--- a/levels/main.tscn
+++ b/levels/main.tscn
@@ -215,6 +215,26 @@ text = "Vidas: 3"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="ClickHintLabel" type="Label" parent="."]
+visible = false
+anchors_preset = -1
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+offset_left = -460.0
+offset_top = 180.0
+offset_right = -40.0
+offset_bottom = 240.0
+grow_horizontal = 0
+grow_vertical = 0
+theme = ExtResource("7_6et1j")
+theme_override_colors/font_color = Color(0.870588, 0.960784, 0.929412, 1)
+theme_override_font_sizes/font_size = 32
+text = "Dé click en cualquier lugar de la pantalla para tirar el dado"
+horizontal_alignment = 2
+autowrap_mode = 3
+
 [node name="ColorOverlay" type="CanvasLayer" parent="."]
 layer = -5
 


### PR DESCRIPTION
## Summary
- integrate new dice and pawn sound effects through the SFX manager and trigger them during rolls and landings
- randomize exam answer order and add an instructional hint after the tutorial in game mode
- expose the hyperthermia guide from the main menu and wire the music volume slider to the music bus

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690209cafdf08333a634b1dd31960a6c